### PR TITLE
Issue #2: Make use of next() instead of nextPosix() to support Window…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
 simulator
 zig
+src/zig-cache
+
+#Project Files
+.idea
+*.iml


### PR DESCRIPTION
# Summary
* `next()` instead of `nextPosix()` in order for the vopr to work on non-ux based platforms. 
* Updated `.ignore` to exclude project files and cache.

# Testing
![testing_windows](https://user-images.githubusercontent.com/1992108/133105030-2fe8563d-5d2a-449e-86ec-82ea9464d5bd.png)

# Running
### With seed
`zig run src/simulator.zig -OReleaseSafe -- 123`
### Without seed
`zig run src/simulator.zig -OReleaseSafe`


@jorangreef Ready for review. Testing under Windows 10 added. Please see ^ ^ ^.
